### PR TITLE
Import pyspec's saferef

### DIFF
--- a/python/client/SpecEventsDispatcher.py
+++ b/python/client/SpecEventsDispatcher.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
    import Queue as queue
 
-import saferef 
+from pyspec.client import saferef
 from pyspec.css_logger import log, log_exception
 
 DEBUG=4  # debug level for this module


### PR DESCRIPTION
I have been working with a larger code base (mxcubecore to be exact) that has multiple versions of saferef in other packages.  By default the import was pulling in the wrong code and the dispatching was not working right.  This change makes itimport the correct module.

Phil
  