### PR TITLE
In file/spec.py, accommodate lines starting with "Error on epics_get"

### DIFF
--- a/python/file/spec.py
+++ b/python/file/spec.py
@@ -374,7 +374,11 @@ class FileBlock:
                     content = sline[widx:].strip()
 
                     if metakey in self.funcs:
-                        self.funcs[metakey](content.strip(), metaval)
+                        try:
+                            self.funcs[metakey](content.strip(), metaval)
+                        except:
+                            self.wrongLine(lineno, sline,
+                                           "unknown line (%s) " % metakey)
                     else:
                         self.wrongLine(lineno, sline,
                                        "unknown header line (%s) " % metakey)


### PR DESCRIPTION
We have some macros that add userlines to our spec files with values of EPICS PVs in them. When there is an issue with the connection between spec an EPICS, the line that gets added to the file is `Error on epics_get("<PV_name>"):  Not connected.` Since this begins with "E", `pyspec.file.spec.FileBlock.parse()` treats it the same way as actual epoch lines beginning with "#E", and attempts to convert "on epics_get("<PV_name>"):  Not connected." to an int (and obviously fails to do so). Adding this `try...except` makes it possible to parse scans that have these EPICS error lines in them.