### PR TITLE
In file/spec.py, accommodate files containing multiple adjacent heade…

### DIFF
--- a/python/file/spec.py
+++ b/python/file/spec.py
@@ -228,7 +228,7 @@ class FileSpec(list):
                 if fb is not None:
                     fb.end()
 
-                if btype == 'F' or (btype == 'E' and not self.inheader):
+                if btype in ['F', 'E']:
                     if btype == 'F':
                         self.origfilename = sline[2:].strip()
                     fb = Header(blockstart, blockline)


### PR DESCRIPTION
…r sections

When there is more than one adjacent header section beginning with "#E" or "#F", parse them as separate header sections. When multiple adjacent sections all contain "#O" lines with motor names, the `FileBlock` to which they all belong has duplicate copies of the motor names, so all following scans have a mismatching # of motor positions and motor names, so those scans have `scan.motor_positions == None`.